### PR TITLE
Add .env instructions to README to allow for server startup

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -25,14 +25,24 @@ cd cs467_job_tracker/server
 npm install
 ```
 ### Usage
+1. Create a .env file in the server directory with the following environment variable: 
 
-1. Start the development server:
+```
+SESSION_SECRET = 'your_secret_here'
+GOOGLE_CLIENT_ID = 'your_client_id_here'
+GOOGLE_CLIENT_SECRET = 'your_client_secret_here'
+GITHUB_CLIENT_ID = 'your_client_id_here'
+GITHUB_CLIENT_SECRET = 'your_client_secret_here'
+```
+
+```
+2. Start the development server:
 
 ```
 npm start
 ```
 
-2. Open your web browser and visit http://localhost:3000 to access the server.
+3. Open your web browser and visit http://localhost:3000 to access the server.
 
 ### Development
 * The backend server is built with Node.js and Express.


### PR DESCRIPTION
When attempting to run `npm start` on my local machine, I found some .env variables that need to be added for the server to able to start up. Adding the instructions for this to README to help others going forward.