### PR TITLE
Update React App to call server via HTTP GET

### DIFF
--- a/client/jest.config.js
+++ b/client/jest.config.js
@@ -6,6 +6,7 @@ Prompt(s): requested help eliminating errors after installing Jest
 module.exports = {
     testEnvironment: 'jsdom',
     moduleNameMapper: {
-        '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js'
+        '\\.(css|less|scss|sass)$': '<rootDir>/__mocks__/styleMock.js',
+        '^axios$': 'axios/dist/node/axios.cjs'
     }
 };

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,26 +1,28 @@
 // src/App.js
-import React from 'react';
-// import axios from 'axios';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import './App.css'; // Import CSS file for styles
 
 function App() {
-  const handleCreateAccount = () => {
-    // Redirect to account creation page
-    console.log('Redirect to account creation');
-  };
+  const [data, setData] = useState(null);
 
-  const handleLogin = () => {
-    // Redirect to login page
-    console.log('Redirect to login');
-  };
+  useEffect(() => {
+    axios.get('http://localhost:3000')
+      .then(response => {
+        setData(response.data);
+      })
+      .catch(error => {
+        console.error('Error fetching data:', error);
+      });
+  }, []);
+
+  if (data === null) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className="app-container">
-      <h1 className="app-title">Welcome to Job Tracker</h1>
-      <div className="button-container">
-        <button className="action-button" onClick={handleCreateAccount}>Create Account</button>
-        <button className="action-button" onClick={handleLogin}>Login</button>
-      </div>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
     </div>
   );
 }

--- a/server/app.mjs
+++ b/server/app.mjs
@@ -11,6 +11,7 @@ import passport from 'passport'
 import { Strategy as googleStrategy } from 'passport-google-oauth20'
 import { Strategy as githubStrategy } from 'passport-github2'
 import dotenv from 'dotenv'
+import cors from 'cors'
 dotenv.config()
 
 // MongoDB connection
@@ -20,6 +21,13 @@ mongoose.connect('mongodb://127.0.0.1:27017/jobTracker')
 
 // Initialize Express app
 const app = express()
+
+/*
+Configure the server to add the Access-Control-Allow-Origin header to its 
+responses. This header tells the browser that it's okay for the React app 
+to access cross-origin resources.
+*/
+app.use(cors());
 
 /*
 Middleware

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "cors": "^2.8.5",
         "dotenv": "^16.4.4",
         "express": "^4.18.2",
         "express-session": "^1.18.0",
@@ -2983,6 +2984,18 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -4980,6 +4993,14 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
       "integrity": "sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q=="
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.1",
@@ -8438,6 +8459,15 @@
         "browserslist": "^4.22.3"
       }
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "create-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -9924,6 +9954,11 @@
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.0.tgz",
       "integrity": "sha512-1orQ9MT1vHFGQxhuy7E/0gECD3fd2fCC+PIX+/jgmU/gI3EpRocXtmtvxCO5x3WZ443FLTLFWNDjl5MPJf9u+Q=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-inspect": {
       "version": "1.13.1",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "supertest": "^6.3.4"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "dotenv": "^16.4.4",
     "express": "^4.18.2",
     "express-session": "^1.18.0",


### PR DESCRIPTION
Updated the frontend react app to call the server via HTTP get request for the '/' endpoint. 

Once I made the update and tried testing, I was receiving the following error in my browser console:

`Access to XMLHttpRequest at '[http://localhost:3000/'](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) from origin 'http://localhost:3001' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.`

I asked GitHub Copilot to explain the error, and this is the response I got:

"This error is related to a security feature implemented in web browsers known as the Same-Origin Policy. It prevents a web page from making requests to a different domain than the one the web page came from.

Cross-Origin Resource Sharing (CORS) is a mechanism that allows many resources (e.g., fonts, JavaScript, etc.) on a web page to be requested from another domain outside the domain from which the resource originated.

In your case, your React app is running on http://localhost:3001 and is trying to access a resource at http://localhost:3000. The browser blocks this by default due to the Same-Origin Policy.

To fix this, you need to configure your server (running on http://localhost:3000) to add the Access-Control-Allow-Origin header to its responses. This header tells the browser that it's okay for the app at http://localhost:3001 to access the resources."

So, I added CORS to the React app and it fixed the issue.